### PR TITLE
Feature/add content type rendering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -220,6 +220,12 @@ be rejected if they 'smell bad'. Specifically, given that this is an app that is
 pushing data over the wire, and therefore hard to debug - lots of logging, and
 lots of comments. Seriously. Lots.
 
+.. NOTE::
+
+  libmagic is required for file detection steps performed when we detect the
+  content type of attachments. On OSX this can be installed with brew, ubuntu
+  seems to have it pre-installed.
+
 Licence
 -------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dj-database-url==0.3.0
 django-jsonfield==0.9.13
 git+https://github.com/sarumont/py-trello.git@766c90dc1dacd2e3fcfc579079a6aab38be43aef
 psycopg2==2.5.4
+python-magic==0.4.6

--- a/test_app/templates/trello_webhooks/addAttachmentToCard.html
+++ b/test_app/templates/trello_webhooks/addAttachmentToCard.html
@@ -1,0 +1,3 @@
+{% load trello_webhook_tags %}
+<strong>{{action.memberCreator.initials}}</strong> added attachment "<strong> {% get_attachment_link action.data.attachment %} </strong>"
+{% include 'trello_webhooks/partials/card_link.html' %}

--- a/test_app/test_settings.py
+++ b/test_app/test_settings.py
@@ -15,6 +15,8 @@ INSTALLED_APPS = ('trello_webhooks',)
 
 try:
     import django_nose  # noqa
+
+    INSTALLED_APPS = ('trello_webhooks', 'django_nose')
     TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
     print u"TEST_RUNNER set to use django_nose"
     import coverage  # noqa

--- a/test_app/test_settings.py
+++ b/test_app/test_settings.py
@@ -16,7 +16,7 @@ INSTALLED_APPS = ('trello_webhooks',)
 try:
     import django_nose  # noqa
 
-    INSTALLED_APPS = ('trello_webhooks', 'django_nose')
+    INSTALLED_APPS = ('test_app', 'trello_webhooks', 'django_nose')
     TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
     print u"TEST_RUNNER set to use django_nose"
     import coverage  # noqa

--- a/trello_webhooks/contenttypes.py
+++ b/trello_webhooks/contenttypes.py
@@ -39,8 +39,8 @@ def get_attachment_content_type(url):
     return magic.from_buffer(read_chunk(url), mime=True)
 
 
-def attachment_is_image(url):
-    return get_attachment_content_type(url) in known_extensions
+def contenttype_is_image(ctype):
+    return ctype in known_extensions
 
 
 def merge_content_type(attachment):

--- a/trello_webhooks/contenttypes.py
+++ b/trello_webhooks/contenttypes.py
@@ -1,0 +1,54 @@
+import magic
+import requests
+from functools import wraps
+
+# https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Supported_image_formats
+known_extensions = {
+    'image/jpeg': 'jpg',
+    'image/gif': 'gif',
+    'image/png': 'png',
+    'image/bmp': 'bmp',
+    'image/x-windows-bmp': 'bmp',
+    'image/svg+xml': 'svg',
+    'image/x-icon': 'ico',
+}
+
+
+def memo(func):
+    cache = {}
+    @wraps(func)
+    def wrap(*args):
+        if args not in cache:
+            cache[args] = func(*args)
+        return cache[args]
+    return wrap
+
+
+def read_chunk(url):
+    """Returns the 1st 1024 bytes of a given url
+
+    This is typically enough to determine the mimetype of a given file"""
+    rsp = requests.get(url, stream=True)
+    return next(rsp.iter_content(1024))
+
+
+# is it a safe assumption that an attachment url cannot be overwritten and
+# so we do not need to check the same url more than once?
+@memo
+def get_attachment_content_type(url):
+    return magic.from_buffer(read_chunk(url), mime=True)
+
+
+def attachment_is_image(url):
+    return get_attachment_content_type(url) in known_extensions
+
+
+def merge_content_type(attachment):
+    """If applicable, update attachment with the attachment contenttype"""
+    try:
+        ctype = get_attachment_content_type(attachment['previewUrl'])
+    except (TypeError, KeyError):
+        ctype = u''
+    if ctype and attachment:
+        attachment['contentType'] = ctype
+    return attachment

--- a/trello_webhooks/management/commands/setcontenttype.py
+++ b/trello_webhooks/management/commands/setcontenttype.py
@@ -1,0 +1,17 @@
+# # -*- coding: utf-8 -*-
+# sync webhooks down from Trello
+import logging
+
+from django.core.management.base import BaseCommand
+from trello_webhooks.models import CallbackEvent
+
+logger = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+    help = u"Sets contentType (if appropriate) for all `CallbackEvent`s"
+
+    def handle(self, *args, **options):
+        callback_events = list(CallbackEvent.objects.filter(event_type='addAttachmentToCard'))
+        for ce in callback_events:
+            ce.save()
+        logger.info(u"Updated {} CallbackEvent instances".format(len(callback_events)))

--- a/trello_webhooks/templatetags/trello_webhook_tags.py
+++ b/trello_webhooks/templatetags/trello_webhook_tags.py
@@ -1,7 +1,9 @@
 # Template tags used in BackOffice only
 from django import template
+from django.utils.safestring import mark_safe
 
 from trello_webhooks.settings import TRELLO_API_KEY
+from trello_webhooks import contenttypes
 
 register = template.Library()
 
@@ -52,3 +54,14 @@ def trello_updates(new, old):
         return {k: (v, new[k]) for k, v in old.iteritems()}
     except KeyError:
         return {k: (v, None) for k, v in old.iteritems()}
+
+
+@register.simple_tag
+def get_attachment_link(attachment):
+    ctype = attachment.get('contentType', '')
+    if contenttypes.contenttype_is_image(ctype):
+        inner = u'<img src="{url}">'.format(**attachment)
+    else:
+        inner = attachment['name']
+    kwargs = {'url': attachment['url'], 'inner': inner}
+    return mark_safe(u'<a href="{url}">{inner}</a>'.format(**kwargs))

--- a/trello_webhooks/tests/sample_data/addAttachmentToCard.json
+++ b/trello_webhooks/tests/sample_data/addAttachmentToCard.json
@@ -1,0 +1,80 @@
+{
+    "action": {
+        "data": {
+            "attachment": {
+                "id": "549029d1fb1ce0bfa8f05117",
+                "name": "2014-12-08 10.24.28.png",
+                "previewUrl": "https://trello-attachments.s3.amazonaws.com/5486d8cf77b945bc1a8cdf09/600x1067/47a03da431c1ea14414ed72f1ddc88e4/2014-12-08_10.24.28.png",
+                "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/5486d8cf77b945bc1a8cdf09/720x1280/a3789e45dc3811855fec2f0c6de907f7/2014-12-08_10.24.28.png",
+                "url": "https://trello-attachments.s3.amazonaws.com/5486d8cf77b945bc1a8cdf09/720x1280/a3789e45dc3811855fec2f0c6de907f7/2014-12-08_10.24.28.png"
+            },
+            "board": {
+                "id": "5476fab52086e26047fa328c",
+                "name": "Django Trello Webhooks Test Board",
+                "shortLink": "TAAnwdP9"
+            },
+            "card": {
+                "id": "5486d8cf77b945bc1a8cdf09",
+                "idShort": 23,
+                "name": "this is new",
+                "shortLink": "JHdpHgyb"
+            }
+        },
+        "date": "2014-12-16T12:47:15.275Z",
+        "id": "549029d3fb1ce0bfa8f0511e",
+        "idMemberCreator": "4f55dc2f8e0358c24d194be0",
+        "memberCreator": {
+            "avatarHash": "852f1ba717618e2d0ba0c0a8de5eaad4",
+            "fullName": "Hugo Rodger-Brown",
+            "id": "4f55dc2f8e0358c24d194be0",
+            "initials": "HRB",
+            "username": "hrb"
+        },
+        "type": "addAttachmentToCard"
+    },
+    "model": {
+        "closed": false,
+        "desc": "",
+        "descData": null,
+        "id": "5476fab52086e26047fa328c",
+        "idOrganization": null,
+        "labelNames": {
+            "black": "",
+            "blue": "",
+            "green": "",
+            "lime": "",
+            "orange": "",
+            "pink": "",
+            "purple": "",
+            "red": "",
+            "sky": "",
+            "yellow": ""
+        },
+        "name": "Django Trello Webhooks Test Board",
+        "pinned": false,
+        "prefs": {
+            "background": "blue",
+            "backgroundBrightness": "unknown",
+            "backgroundColor": "#0079BF",
+            "backgroundImage": null,
+            "backgroundImageScaled": null,
+            "backgroundTile": false,
+            "calendarFeedEnabled": false,
+            "canBeOrg": true,
+            "canBePrivate": true,
+            "canBePublic": true,
+            "canInvite": true,
+            "cardAging": "regular",
+            "cardCovers": true,
+            "comments": "public",
+            "invitations": "members",
+            "permissionLevel": "public",
+            "selfJoin": false,
+            "voting": "disabled"
+        },
+        "shortUrl": "https://trello.com/b/TAAnwdP9",
+        "url": "https://trello.com/b/TAAnwdP9/django-trello-webhooks-test-board"
+    }
+}
+ 
+

--- a/trello_webhooks/tests/test_contenttypes.py
+++ b/trello_webhooks/tests/test_contenttypes.py
@@ -1,0 +1,39 @@
+import mock
+from nose.tools import raises, assert_equal
+from trello_webhooks import contenttypes
+
+
+def make_breaking_function():
+    values = {}
+    def breaking_(value):
+        if value in values:
+            raise ValueError("Cannot re-add same value %s" % repr(value))
+        values[value] = 1
+    return breaking_
+
+
+
+@raises(ValueError)
+def test_example_of_breakage():
+    # the non memoized version raises an error on the second call
+    breaking = make_breaking_function()
+    breaking(1)
+    breaking(1)
+
+
+def test_memo_calls_once():
+    # the memoized version can be called twice with the same value
+    breaking = make_breaking_function()
+    non_breaking = contenttypes.memo(breaking)
+    non_breaking(1)
+    non_breaking(1)
+
+
+def fake_chunk(url):
+    return u''
+
+
+@mock.patch('trello_webhooks.contenttypes.read_chunk', fake_chunk)
+def test_get_attachment_content_type():
+    mtype = contenttypes.get_attachment_content_type('http://example.com')
+    assert_equal(mtype, 'application/x-empty')

--- a/trello_webhooks/tests/test_html.py
+++ b/trello_webhooks/tests/test_html.py
@@ -1,0 +1,18 @@
+import collections
+from django.template.loader import render_to_string
+from nose.tools import assert_true
+
+
+def vivify():
+    return collections.defaultdict(vivify)
+
+
+def test_rendering():
+    att = {'contentType': 'image/png', u'url': u'https://foo.com', 'name': u'FOO'}
+    context = vivify()
+    context['action']['data']['attachment'] = att
+    context['action']['memberCreator']['initials'] = u'RJS'
+    template = 'trello_webhooks/addAttachmentToCard.html'
+    html = render_to_string(template, context).strip()
+    expected = u'<strong>RJS</strong> added attachment "<strong> <a href="https://foo.com"><img src="https://foo.com"></a> </strong>"'
+    assert_true(html.startswith(expected))

--- a/trello_webhooks/tests/test_models.py
+++ b/trello_webhooks/tests/test_models.py
@@ -52,6 +52,10 @@ def mock_trello_sync_x(webhook, verb):
     return webhook
 
 
+def mock_get_attachment_content_type(url):
+    return 'image/png'
+
+
 class WebhookModelTests(TestCase):
 
     def test_default_properties(self):
@@ -261,6 +265,15 @@ class CallbackEventModelTest(TestCase):
 
     def test_save(self):
         pass
+
+    @mock.patch('trello_webhooks.contenttypes.get_attachment_content_type',
+                mock_get_attachment_content_type)
+    def test_add_attachment_event(self):
+        ce = CallbackEvent()
+        ce.event_payload = get_sample_data('addAttachmentToCard', 'text')
+        ce._merge_content_type()
+        ad = ce.action_data
+        self.assertTrue(ad['attachment']['contentType'] == 'image/png')
 
     def test_action_data(self):
         ce = CallbackEvent()

--- a/trello_webhooks/tests/test_templatetags.py
+++ b/trello_webhooks/tests/test_templatetags.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 from django.test import TestCase
+from nose.tools import assert_equal
 
+from trello_webhooks.tests import get_sample_data
+from trello_webhooks import contenttypes
 from trello_webhooks.settings import TRELLO_API_KEY
 from trello_webhooks.templatetags.trello_webhook_tags import (
     trello_api_key,
-    trello_updates
+    trello_updates,
+    get_attachment_link,
 )
 
 
@@ -28,3 +32,18 @@ class TemplateTagTests(TestCase):
             trello_updates(new, old),
             {'pos': (1, None)}
         )
+
+
+def test_attachment_rendering():
+    test_data = [
+        ({'contentType': 'image/png', u'url': u'foo.com', 'name': u'FOO'}, u'<a href="foo.com"><img src="foo.com"></a>'),
+        ({'contentType': 'application/json', u'url': u'bar.com', 'name': u'BAR'}, u'<a href="bar.com">BAR</a>'),
+        ({u'url': u'baz.com', 'name': u'BAZ'}, u'<a href="baz.com">BAZ</a>'),
+    ]
+    for att, expected in test_data:
+        yield check_get_attachment_link, att, expected
+
+
+def check_get_attachment_link(attachment, expected):
+    link = get_attachment_link(attachment)
+    assert_equal(link, expected)


### PR DESCRIPTION
I think most of this is fairly straight forward, the parts that need some explanation are:

1. The memoisation - I found the webhooks seem pretty undocumented but I speculate that urls for an attachment are unique and so I memoised the filetype lookups to avoid repeated calls to the same file

2. Use of python-magic - again, not knowing much about how Trello handles attachments I have found in the past that the simplest case of just checking extension is not reliable. Checking the content-type the server responds with normally works but since it is possible for a server to lie about this (although I'm sure that s3 doesn't) I prefer to test the file itself to be sure