### PR TITLE
Improve template for `addAttachmentToCard` event

### DIFF
--- a/test_app/templates/trello_webhooks/addAttachmentToCard.html
+++ b/test_app/templates/trello_webhooks/addAttachmentToCard.html
@@ -1,0 +1,2 @@
+{% load test_app_tags %}<strong>{{action.memberCreator.initials}}</strong> added attachment <a href="{{action.data.attachment.url}}">{% with action.data.attachment.url|is_image as is_img %}{% if is_img %}<img src="{{action.data.attachment.url}}">{% else %}"<strong>{{action.data.attachment.name}}</strong>"{% endif %}{% endwith %}</a>
+{% include 'trello_webhooks/partials/card_link.html' %}

--- a/test_app/templatetags/test_app_tags.py
+++ b/test_app/templatetags/test_app_tags.py
@@ -1,0 +1,18 @@
+import mimetypes
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def is_image(url):
+    """Check the content-type for `url`. Returns `True` if it's an image
+    or `False` if can't be guessed or isn't an image.
+
+    """
+    # The first element is the content-type
+    contenttype = mimetypes.guess_type(url)[0]
+    if contenttype is not None and contenttype.startswith('image/'):
+        return True
+    return False

--- a/test_app/test_settings.py
+++ b/test_app/test_settings.py
@@ -11,7 +11,8 @@ DATABASES = {
 }
 
 # the django apps aren't required for the tests,
-INSTALLED_APPS = ('trello_webhooks',)
+INSTALLED_APPS = ('test_app',
+                  'trello_webhooks',)
 
 try:
     import django_nose  # noqa

--- a/test_app/tests/test_template.py
+++ b/test_app/tests/test_template.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from django.template.loader import render_to_string
+from django.test import TestCase
+
+
+class TemplateTests(TestCase):
+
+    def test_addAttachmentToCard(self):
+        template = 'trello_webhooks/addAttachmentToCard.html'
+
+        # attachement is an image
+        url = 'http://example.com/img.png'
+        context = {"action": {"data": {"attachment":{"url": url}}}}
+        result = render_to_string(template, context)
+        self.assertIn('<img src="http://example.com/img.png">', result)
+
+        # attachement is *not* an image
+        url = 'http://example.com/main.js'
+        context = {"action": {"data": {"attachment":{"url": url,"name": "main.js"}}}}
+        result = render_to_string(template, context)
+        self.assertIn('"<strong>main.js</strong>"', result)

--- a/test_app/tests/test_templatetags.py
+++ b/test_app/tests/test_templatetags.py
@@ -1,0 +1,23 @@
+
+from django.test import TestCase
+
+from test_app.templatetags.test_app_tags import is_image
+
+
+class TemplateTagsTests(TestCase):
+
+    def test_is_image(self):
+        # no attachment
+        value = ''
+        result = is_image(value)
+        self.assertFalse(result)
+
+        # attachment is an image
+        value = 'http://example.com/img.png'
+        result = is_image(value)
+        self.assertTrue(result)
+
+        # attachment is *not* an image
+        value = 'http://example.com/main.js'
+        result = is_image(value)
+        self.assertFalse(result)


### PR DESCRIPTION
- Add a custom template `addAttachmentToCard.html` to show an image
  instead of the file name when the attachment is an image.
- Add template tag to check if an attachment is an image.
- Add `test_app` to `test_app.test_settings` to include the app in
  the tests.
