### PR TITLE
Display image attachments in HC as inline images

### DIFF
--- a/test_app/signals.py
+++ b/test_app/signals.py
@@ -37,7 +37,7 @@ def on_callback_received(sender, **kwargs):
     html = event.render()
     if settings.HIPCHAT_ENABLED:
         logger.debug(
-            u"Message sent to HipChat [%s]: %r",
+            u"Message sent to HipChat [%s]: %s %r",
             send_to_hipchat(html), event, event.webhook
         )
     else:

--- a/test_app/templates/trello_webhooks/addAttachmentToCard.html
+++ b/test_app/templates/trello_webhooks/addAttachmentToCard.html
@@ -1,0 +1,3 @@
+{% load test_app_tags %}
+<strong>{{action.memberCreator.initials}}</strong> added attachment <strong><a href="{{action.data.attachment.url}}">{{action.data.attachment|render_attachment}}</a></strong>
+{% include 'trello_webhooks/partials/card_link.html' %}

--- a/test_app/templatetags/__init__.py
+++ b/test_app/templatetags/__init__.py
@@ -1,0 +1,2 @@
+import test_app_tags
+__all__ = ['test_app_tags']

--- a/test_app/templatetags/test_app_tags.py
+++ b/test_app/templatetags/test_app_tags.py
@@ -1,0 +1,24 @@
+from django.utils.html import format_html
+from trello_webhooks import content_types
+from trello_webhooks.templatetags.trello_webhook_tags import register
+
+
+@register.filter
+def render_attachment(attachment):
+    """Render a card attachment
+
+    This will return either the name of the file or an img tag
+    if the attachment content type is an image.
+
+    Args:
+        attachment: an event data attachment dictionary
+    Returns:
+        an html string representation of the attachment
+    """
+    if content_types.is_image(attachment.get('mimeType') or ''):
+        return format_html(
+            '<br><img src="{}" alt="{}">',
+            attachment.get('url') or '',
+            attachment.get('name') or '',
+        )
+    return '"{}"'.format(attachment.get('name'))

--- a/test_app/tests/test_templatetags.py
+++ b/test_app/tests/test_templatetags.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from django.test import TestCase
+
+from test_app.templatetags.test_app_tags import render_attachment
+
+
+class TemplateTagTests(TestCase):
+    def test_render_attachment(self):
+        # Test empty mime type
+        attachment = {
+            'url': 'http://example.com/foo.ext',
+            'name': 'foo.ext',
+            'mimeType': None,
+        }
+        self.assertEqual(
+            render_attachment(attachment),
+            '"foo.ext"'
+        )
+
+        # Test random mime type
+        attachment['mimeType'] = 'html/text'
+        self.assertEqual(
+            render_attachment(attachment),
+            '"foo.ext"'
+        )
+
+        # Test image mime type
+        attachment['mimeType'] = 'image/png'
+        self.assertEqual(
+            render_attachment(attachment),
+            '<br><img src="http://example.com/foo.ext" alt="foo.ext">'
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = django171_py27
 
 [testenv]
-commands=python manage.py test trello_webhooks
+commands=python manage.py test trello_webhooks test_app
 setenv =
     DJANGO_SETTINGS_MODULE=test_app.test_settings
     PYTHONPATH={toxinidir}
@@ -17,4 +17,5 @@ deps =
     mock==1.0.1
     coverage==3.7.1
     django-nose==1.2
+    httpretty==0.8.14
     -rrequirements.txt

--- a/trello_webhooks/content_types.py
+++ b/trello_webhooks/content_types.py
@@ -1,0 +1,33 @@
+import logging
+import mimetypes
+
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+
+def request_content_type(url):
+    """Get the url content-type using a HEAD http request."""
+    try:
+        resp = requests.head(url)
+    except requests.RequestException:
+        logger.exception("Unable to fetch attachment content-type")
+    else:
+        return resp.headers.get('content-type')
+
+
+def guess_url_content_type(url):
+    """Return the content-type of a url
+
+    This is by means of inspecting the extension or headers.
+    """
+    guessed_type = mimetypes.guess_type(url)[0]
+    if not guessed_type:
+        guessed_type = request_content_type(url)
+    return guessed_type
+
+
+def is_image(content_type):
+    """Check if a content-type is an image."""
+    return content_type.startswith('image')

--- a/trello_webhooks/management/commands/update_content_type.py
+++ b/trello_webhooks/management/commands/update_content_type.py
@@ -1,0 +1,22 @@
+# # -*- coding: utf-8 -*-
+# Populate missing mimetypes on CallbackEvent attachments
+import logging
+
+from django.core.management.base import BaseCommand
+
+from trello_webhooks.models import CallbackEvent
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Try to populate any missing event attachment mimetypes."
+
+    def handle(self, *args, **options):
+        events = CallbackEvent.objects.filter(event_type="addAttachmentToCard")
+        event_count = events.count()
+        logger.info("Processing %d events..." % event_count)
+        for event in events:
+            event.save()
+        logger.info("Done.")

--- a/trello_webhooks/models.py
+++ b/trello_webhooks/models.py
@@ -245,13 +245,13 @@ class CallbackEvent(models.Model):
     def __unicode__(self):
         if self.id:
             return (
-                "CallbackEvent %i: '%s' raised by webhook %s." %
-                (self.id, self.event_type, self.webhook.id)
+                u"CallbackEvent %i: '%s' raised by webhook %s." %
+                (self.id, self.event_type, self.webhook_id)
             )
         else:
             return (
-                "CallbackEvent: '%s' raised by webhook %s." %
-                (self.event_type, self.webhook.id)
+                u"CallbackEvent: '%s' raised by webhook %s." %
+                (self.event_type, self.webhook_id)
             )
 
     def __str__(self):

--- a/trello_webhooks/tests/sample_data/addAttachmentToCard.json
+++ b/trello_webhooks/tests/sample_data/addAttachmentToCard.json
@@ -1,0 +1,78 @@
+{
+    "action": {
+        "data": {
+            "attachment": {
+                "id": "56daeb501ee0b071346d3a59",
+                "name": "29302_381713684541_4939888_n.jpg",
+                "previewUrl": "https://trello-attachments.s3.amazonaws.com/56dae8c9f623068c605a70dd/480x720/ef992f7726aa0aa50ca07cb69713864c/29302_381713684541_4939888_n.jpg",
+                "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/56dae8c9f623068c605a70dd/480x720/ef992f7726aa0aa50ca07cb69713864c/29302_381713684541_4939888_n.jpg",
+                "url": "https://trello-attachments.s3.amazonaws.com/56dae8c9f623068c605a70dd/480x720/ef992f7726aa0aa50ca07cb69713864c/29302_381713684541_4939888_n.jpg"
+            },
+            "board": {
+                "id": "5565ce6272beb2df1e2b3649",
+                "name": "Personal Development",
+                "shortLink": "2XWdeN90"
+            },
+            "card": {
+                "id": "56dae8c9f623068c605a70dd",
+                "idShort": 7,
+                "name": "Test card",
+                "shortLink": "64ByUJ6r"
+            }
+        },
+        "date": "2016-03-05T14:21:04.901Z",
+        "id": "56daeb501ee0b071346d3a5f",
+        "idMemberCreator": "4e71c5f7424fea00005fb3ce",
+        "memberCreator": {
+            "avatarHash": "03265131c176418484afe227af18589d",
+            "fullName": "Velo Ciraptor",
+            "id": "4e71c5f7424fea00005fb3ce",
+            "initials": "VC",
+            "username": "xxdinoxx"
+        },
+        "type": "addAttachmentToCard"
+    },
+    "model": {
+        "closed": false,
+        "desc": "",
+        "descData": null,
+        "id": "5476fab52086e26047fa328c",
+        "idOrganization": null,
+        "labelNames": {
+            "black": "",
+            "blue": "",
+            "green": "",
+            "lime": "",
+            "orange": "",
+            "pink": "",
+            "purple": "",
+            "red": "",
+            "sky": "",
+            "yellow": ""
+        },
+        "name": "Django Trello Webhooks Test Board",
+        "pinned": false,
+        "prefs": {
+            "background": "blue",
+            "backgroundBrightness": "dark",
+            "backgroundColor": "#0079BF",
+            "backgroundImage": null,
+            "backgroundImageScaled": null,
+            "backgroundTile": false,
+            "calendarFeedEnabled": false,
+            "canBeOrg": true,
+            "canBePrivate": true,
+            "canBePublic": true,
+            "canInvite": true,
+            "cardAging": "regular",
+            "cardCovers": true,
+            "comments": "members",
+            "invitations": "members",
+            "permissionLevel": "private",
+            "selfJoin": false,
+            "voting": "disabled"
+        },
+        "shortUrl": "https://trello.com/b/TAAnwdP9",
+        "url": "https://trello.com/b/TAAnwdP9/django-trello-webhooks-test-board"
+    }
+}

--- a/trello_webhooks/tests/test_content_types.py
+++ b/trello_webhooks/tests/test_content_types.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from django.test import TestCase
+
+from mock import patch
+import requests
+import httpretty
+
+from trello_webhooks import content_types
+
+
+def raise_exception(request, uri, headers):
+    raise requests.RequestException('Something went horribly wrong')
+
+
+class ContentTypeTests(TestCase):
+    def test_is_image(self):
+        self.assertTrue(content_types.is_image("image/png"))
+        self.assertTrue(content_types.is_image("image/jpeg"))
+        self.assertTrue(content_types.is_image("image/gif"))
+        self.assertFalse(content_types.is_image("video/mp4"))
+        self.assertFalse(content_types.is_image("something random"))
+
+    @patch.object(content_types, 'request_content_type',
+                  return_value="image/png")
+    def test_guess_url_content_type(self, mock_request_content_type):
+        sample_url = "http://example.com/some_image.jpg"
+        sample_url_no_ext = "http://example.com/i_have_no_extension"
+
+        ct = content_types.guess_url_content_type(sample_url)
+        self.assertEqual(ct, "image/jpeg")
+        self.assertFalse(mock_request_content_type.called)
+
+        ct = content_types.guess_url_content_type(sample_url_no_ext)
+        self.assertEqual(ct, "image/png")
+        mock_request_content_type.assert_called_once_with(sample_url_no_ext)
+
+    @httpretty.activate
+    def test_request_content_type(self):
+        sample_url = "http://example.com/anything"
+        httpretty.register_uri(
+            httpretty.HEAD, sample_url, status=200,
+            content_type='image/gif'
+        )
+        ct = content_types.request_content_type(sample_url)
+        self.assertEqual(ct, 'image/gif')
+
+        httpretty.register_uri(
+            httpretty.HEAD, sample_url,
+            body=raise_exception
+        )
+        try:
+            content_types.request_content_type(sample_url)
+        except requests.RequestException:
+            self.fail("requests exception not handled")


### PR DESCRIPTION
This implements the above feature as described in [Issue #2](#2).
## Type support

I couldn’t find a comprehensive list of what image types are supported for inline display in HC, so I added support for standard image content-types (`image/...`).
Gifv is supported in HC but is not really an image.
## Type detection

Attachments in the Trello API appear to have a `mimeType` field.
However in my tests it failed to work reliably (was usually null for simple jpegs) so I didn’t use it.

There is no 100% valid solution for detecting the real type of the file without actually inspecting the contents; the extension and mime type can be faked easily. For the purpose of this feature it’s an overkill
to actually download and open a file, so it will just assume the mime type from the extension. Failing that, it will use whatever is reported by a head request on its hosting server.
## Sample

![trello_example](https://cloud.githubusercontent.com/assets/511547/13558791/a31c6832-e402-11e5-8a29-9c5a3bd9353e.png)
