### PR TITLE
Store content type against attachment events

### DIFF
--- a/test_app/templates/trello_webhooks/addAttachmentToCard.html
+++ b/test_app/templates/trello_webhooks/addAttachmentToCard.html
@@ -1,0 +1,3 @@
+{% load app_filters %}
+<strong>{{action.memberCreator.initials}}</strong> added attachment "<strong><a href="{{action.data.attachment.url}}">{{action.data.attachment | attachment_name_or_image}}</a></strong>"
+{% include 'trello_webhooks/partials/card_link.html' %}

--- a/tox.ini
+++ b/tox.ini
@@ -17,4 +17,6 @@ deps =
     mock==1.0.1
     coverage==3.7.1
     django-nose==1.2
+    responses
     -rrequirements.txt
+

--- a/trello_webhooks/management/commands/set_attachment_content_type.py
+++ b/trello_webhooks/management/commands/set_attachment_content_type.py
@@ -1,0 +1,21 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from trello_webhooks.models import CallbackEvent
+
+logger = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+    help = "Set the ContentType of all addAttachmentToCard CallbackEvents in the db"
+
+    def handle(self, *args, **options):
+    	"""
+    	When a CallbackEvent is of type addAttachmentToCard, we automatically ping the URL of the attachment
+    	to find out its content type.  This command will do this for all events of that type e.g. to cover any 
+    	CallbackEvents created before the new feature.
+    	"""
+    	for ce in CallbackEvent.objects.filter(event_type='addAttachmentToCard'):
+			ce.attachment_content_type = ce.discover_attachment_content_type()
+			logger.info(u"CallbackEvent %s: '%s' has content type '%s'", ce.id, ce.attachment_url, ce.attachment_content_type)
+			ce.save()

--- a/trello_webhooks/templatetags/app_filters.py
+++ b/trello_webhooks/templatetags/app_filters.py
@@ -1,0 +1,10 @@
+from django import template
+from django.utils.safestring import mark_safe
+register = template.Library()
+
+@register.filter(name='attachment_name_or_image')
+def attachment_name_or_image(value):
+	if value.attachment_content_type.startswith('image/'):
+		return mark_safe("<img src='%s'/>" % value.attachment_url)
+	else:
+		return value.attachment_name

--- a/trello_webhooks/tests/sample_data/addAttachmentToCard.json
+++ b/trello_webhooks/tests/sample_data/addAttachmentToCard.json
@@ -1,0 +1,77 @@
+{
+  "action": {
+    "type": "addAttachmentToCard",
+    "idMemberCreator": "4e707bf73f6f17ae36001ddc",
+    "memberCreator": {
+      "username": "gareththackeray",
+      "fullName": "Gareth Thackeray",
+      "initials": "GT",
+      "id": "4e707bf73f6f17ae36001ddc",
+      "avatarHash": "ede8ab8d0472c2a375ff1d81f05c3c2b"
+    },
+    "date": "2016-11-25T13:01:18.909Z",
+    "data": {
+      "board": {
+        "id": "4e83079b0511eee01acd8a44",
+        "name": "Admin stuff",
+        "shortLink": "UEHPiQie"
+      },
+      "card": {
+        "idShort": 2,
+        "id": "4e8b7e6edb5d489302c9dc0e",
+        "name": "insurance",
+        "shortLink": "zmCrjWA5"
+      },
+      "attachment": {
+        "name": "puppet1.jpg",
+        "url": "https://trello-attachments.s3.amazonaws.com/4e83079b0511eee01acd8a44/4e8b7e6edb5d489302c9dc0e/a47905dd309ffc072c1857f373893f3b/puppet1.jpg",
+        "previewUrl": "https://trello-attachments.s3.amazonaws.com/4e8b7e6edb5d489302c9dc0e/250x250/7202be64a8dafc90b93bc7be18b1180a/puppet1.jpg.png",
+        "previewUrl2x": "https://trello-attachments.s3.amazonaws.com/4e8b7e6edb5d489302c9dc0e/250x250/7202be64a8dafc90b93bc7be18b1180a/puppet1.jpg.png",
+        "id": "5838361ecd82f97a9825ec7e"
+      }
+    },
+    "id": "5838361ecd82f97a9825ec80"
+  },
+  "model": {
+    "descData": null,
+    "labelNames": {
+      "blue": "",
+      "pink": "",
+      "purple": "",
+      "sky": "",
+      "yellow": "",
+      "green": "",
+      "orange": "",
+      "black": "",
+      "red": "",
+      "lime": ""
+    },
+    "name": "Admin stuff",
+    "shortUrl": "https://trello.com/b/UEHPiQie",
+    "idOrganization": "4e83076f2b76fee61a2ea4eb",
+    "pinned": false,
+    "url": "https://trello.com/b/UEHPiQie/admin-stuff",
+    "closed": false,
+    "prefs": {
+      "permissionLevel": "org",
+      "cardCovers": true,
+      "backgroundColor": "#0079BF",
+      "selfJoin": true,
+      "backgroundBrightness": "dark",
+      "comments": "members",
+      "invitations": "members",
+      "canBePrivate": true,
+      "backgroundImage": null,
+      "backgroundTile": false,
+      "background": "blue",
+      "canBeOrg": true,
+      "canInvite": true,
+      "backgroundImageScaled": null,
+      "calendarFeedEnabled": false,
+      "voting": "disabled",
+      "canBePublic": true
+    },
+    "id": "4e83079b0511eee01acd8a44",
+    "desc": ""
+  }
+}

--- a/trello_webhooks/tests/test_templatetags.py
+++ b/trello_webhooks/tests/test_templatetags.py
@@ -7,6 +7,10 @@ from trello_webhooks.templatetags.trello_webhook_tags import (
     trello_updates
 )
 
+from trello_webhooks.templatetags.app_filters import (
+    attachment_name_or_image
+)
+
 
 class TemplateTagTests(TestCase):
 
@@ -28,3 +32,16 @@ class TemplateTagTests(TestCase):
             trello_updates(new, old),
             {'pos': (1, None)}
         )
+
+    def test_attachment_name_or_image_is_image(self):
+        self.assertEqual(attachment_name_or_image(MockCallbackEvent('image/jpeg')), "<img src='attachmentUrl'/>")
+
+    def test_attachment_name_or_image_is_name(self):
+        self.assertEqual(attachment_name_or_image(MockCallbackEvent('text/plain')), "attachmentName")
+
+class MockCallbackEvent(object):
+    attachment_url = 'attachmentUrl'
+    attachment_name = 'attachmentName'
+
+    def __init__(self, attachment_content_type):
+        self.attachment_content_type = attachment_content_type


### PR DESCRIPTION
Some notes about what I did / what I might want to do differently:

1. I added a few extra properties to CallbackEvent than the "canonical" solution suggested sensible.  Reason being that I felt the knowledge of how to access this data from the JSON should be in the model code rather than the view / filter knowing the exact path through the JSON.

2. Maybe the attachment_name_or_image template filter should be in the test_app, since the view that uses it is there.

3. Nothing in the way of exception management.  I guess realistically if Trello is sending a webhook it's probably serving its images too, but we shouldn't *really* rely on this and we should swallow any exceptions on setting content type.  Retry mechanism seems overkill.

4. I did actually get the whole app up and running with ngrok etc.  I had a lot to learn!  The Trello API area is weirdly unintuitive I thought.

5. If I hadn't run the app I'm not sure I'd have known where the content type was in the JSON...  did I miss something?

