### PR TITLE
display image attachments in HipChat as inline images, not links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ coverage.xml
 docs/_build/
 
 test_app/static
+coverage_reports
+
+# MacOS related
+.DS_Store

--- a/test_app/templates/trello_webhooks/addAttachmentToCard.html
+++ b/test_app/templates/trello_webhooks/addAttachmentToCard.html
@@ -1,0 +1,2 @@
+<strong>{{action.memberCreator.initials}}</strong> added attachment "<strong><a href="{{action.data.attachment.url}}">{{action.data.attachment | format_attachment}}</a></strong>"
+{% include 'trello_webhooks/partials/card_link.html' %}

--- a/test_app/templatetags/attachment.py
+++ b/test_app/templatetags/attachment.py
@@ -1,0 +1,12 @@
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.filter
+def format_attachment(attachment):
+    if attachment.get('content_type', '').startswith('image'):
+        return mark_safe("<img src='%s'>" % attachment.get('url'))
+    else:
+        return attachment.get('name')

--- a/test_app/tests/test_templatetags.py
+++ b/test_app/tests/test_templatetags.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+
+from test_app.templatetags.attachment import format_attachment
+
+class AttachmentTemplateTagTests(TestCase):
+
+    def test_display_inline_images(self):
+        attachment = {
+            'name': 'test-image.jpg',
+            'url': 'https://example.com/test-image.jpg',
+            'content_type': 'image/jpeg'
+        }
+        self.assertEqual(format_attachment(attachment), "<img src='%s'>" % attachment['url'])
+
+    def test_display_name_for_attachments_other_than_images(self):
+        attachment = {
+            'name': 'test-csv.csv',
+            'url': 'https://test-csv.csv',
+            'content_type': 'text/csv'
+        }
+        self.assertEqual(format_attachment(attachment), "test-csv.csv")

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = django171_py27
 
 [testenv]
-commands=python manage.py test trello_webhooks
+commands=python manage.py test trello_webhooks test_app
 setenv =
     DJANGO_SETTINGS_MODULE=test_app.test_settings
     PYTHONPATH={toxinidir}

--- a/trello_webhooks/management/commands/add_content_type_of_all_the_attachments.py
+++ b/trello_webhooks/management/commands/add_content_type_of_all_the_attachments.py
@@ -1,0 +1,29 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from trello_webhooks.models import CallbackEvent
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+
+    help = """
+    	Adds content type of the attachments to all historic callback events.
+    	"""
+
+    def handle(self, *args, **options):
+
+        callback_events = CallbackEvent.objects.filter(event_type='addAttachmentToCard')
+
+        if not callback_events:
+        	logger.warning("No CallbackEvent found for adding attachment content type")
+
+        try:
+	        for event in callback_events:
+	            event.save()
+	        logger.info("Content types for attachments added successfully")
+	    except Exception as e:
+	    	# Very generic exception handling as we're wrapping (or may be) lots of behaviour on callback event save 
+	    	logger.error("Error on adding content type of attachment for event {}. Error:{}".format(event.id, e))

--- a/trello_webhooks/tests/sample_data/addAttachmentToCard.json
+++ b/trello_webhooks/tests/sample_data/addAttachmentToCard.json
@@ -1,0 +1,76 @@
+{
+    "action": {
+        "data": {
+            "attachment": {
+                "id": "54875c2ad0d0edaa61417e03",
+                "name": "2014-11-02-16-25-01.csv",
+                "url": "https://trello-attachments.s3.amazonaws.com/54874d58464f79e03c6fbccd/54874eeacffda7d35db29f7a/6001b9fbee26bcc9c3722ca2761101a7/2014-11-02-16-25-01.csv"
+            },
+            "board": {
+                "id": "54874d58464f79e03c6fbccd",
+                "name": "new",
+                "shortLink": "d7ABa4ga"
+            },
+            "card": {
+                "id": "54874eeacffda7d35db29f7a",
+                "idShort": 3,
+                "name": "s5rthsr5",
+                "shortLink": "eCoyfrel"
+            }
+        },
+        "date": "2014-12-09T20:31:38.354Z",
+        "id": "54875c2ad0d0edaa61417e04",
+        "idMemberCreator": "5199e7cd1b5b528f6e01473b",
+        "memberCreator": {
+            "avatarHash": "c69d0761cd553b107d049d48d45d075b",
+            "fullName": "Marcel Kornblum",
+            "id": "5199e7cd1b5b528f6e01473b",
+            "initials": "MK",
+            "username": "marcelkornblum"
+        },
+        "type": "addAttachmentToCard"
+    },
+    "model": {
+        "closed": false,
+        "desc": "",
+        "descData": null,
+        "id": "54874d58464f79e03c6fbccd",
+        "idOrganization": null,
+        "labelNames": {
+            "black": "",
+            "blue": "",
+            "green": "",
+            "lime": "",
+            "orange": "",
+            "pink": "",
+            "purple": "",
+            "red": "",
+            "sky": "",
+            "yellow": ""
+        },
+        "name": "new",
+        "pinned": false,
+        "prefs": {
+            "background": "blue",
+            "backgroundBrightness": "unknown",
+            "backgroundColor": "#0079BF",
+            "backgroundImage": null,
+            "backgroundImageScaled": null,
+            "backgroundTile": false,
+            "calendarFeedEnabled": false,
+            "canBeOrg": true,
+            "canBePrivate": true,
+            "canBePublic": true,
+            "canInvite": true,
+            "cardAging": "regular",
+            "cardCovers": true,
+            "comments": "members",
+            "invitations": "members",
+            "permissionLevel": "private",
+            "selfJoin": false,
+            "voting": "disabled"
+        },
+        "shortUrl": "https://trello.com/b/d7ABa4ga",
+        "url": "https://trello.com/b/d7ABa4ga/new"
+    }
+}

--- a/trello_webhooks/tests/sample_data/addAttachmentToCardImage.json
+++ b/trello_webhooks/tests/sample_data/addAttachmentToCardImage.json
@@ -1,0 +1,78 @@
+{
+    "action": {
+        "data": {
+            "attachment": {
+                "id": "54875c21f0734e1592af4505",
+                "name": "clear-water-glass.jpg",
+                "previewUrl": "http://www.ecowater.com/wp-content/uploads/2015/07/clear-water-glass.jpg",
+                "previewUrl2x": "http://www.ecowater.com/wp-content/uploads/2015/07/clear-water-glass.jpg",
+                "url": "http://www.ecowater.com/wp-content/uploads/2015/07/clear-water-glass.jpg"
+            },
+            "board": {
+                "id": "54874d58464f79e03c6fbccd",
+                "name": "new",
+                "shortLink": "d7ABa4ga"
+            },
+            "card": {
+                "id": "54874eeacffda7d35db29f7a",
+                "idShort": 3,
+                "name": "s5rthsr5",
+                "shortLink": "eCoyfrel"
+            }
+        },
+        "date": "2014-12-09T20:31:30.550Z",
+        "id": "54875c22f0734e1592af450a",
+        "idMemberCreator": "5199e7cd1b5b528f6e01473b",
+        "memberCreator": {
+            "avatarHash": "c69d0761cd553b107d049d48d45d075b",
+            "fullName": "Marcel Kornblum",
+            "id": "5199e7cd1b5b528f6e01473b",
+            "initials": "MK",
+            "username": "marcelkornblum"
+        },
+        "type": "addAttachmentToCard"
+    },
+    "model": {
+        "closed": false,
+        "desc": "",
+        "descData": null,
+        "id": "54874d58464f79e03c6fbccd",
+        "idOrganization": null,
+        "labelNames": {
+            "black": "",
+            "blue": "",
+            "green": "",
+            "lime": "",
+            "orange": "",
+            "pink": "",
+            "purple": "",
+            "red": "",
+            "sky": "",
+            "yellow": ""
+        },
+        "name": "new",
+        "pinned": false,
+        "prefs": {
+            "background": "blue",
+            "backgroundBrightness": "unknown",
+            "backgroundColor": "#0079BF",
+            "backgroundImage": null,
+            "backgroundImageScaled": null,
+            "backgroundTile": false,
+            "calendarFeedEnabled": false,
+            "canBeOrg": true,
+            "canBePrivate": true,
+            "canBePublic": true,
+            "canInvite": true,
+            "cardAging": "regular",
+            "cardCovers": true,
+            "comments": "members",
+            "invitations": "members",
+            "permissionLevel": "private",
+            "selfJoin": false,
+            "voting": "disabled"
+        },
+        "shortUrl": "https://trello.com/b/d7ABa4ga",
+        "url": "https://trello.com/b/d7ABa4ga/new"
+    }
+}

--- a/trello_webhooks/tests/test_models.py
+++ b/trello_webhooks/tests/test_models.py
@@ -315,3 +315,19 @@ class CallbackEventModelTest(TestCase):
         self.assertEqual(ce.card_name, None)
         ce.event_payload = get_sample_data('createCard', 'text')
         self.assertEqual(ce.card_name, ce.event_payload['action']['data']['card']['name'])  # noqa
+
+    def test_attachment_content_type_with_csv(self):
+        ce = CallbackEvent(event_type='addAttachmentToCard')
+        ce.event_payload = get_sample_data('addAttachmentToCard', 'text')
+        self.assertTrue('text/csv' in ce.attachment_content_type)
+
+    def test_attachment_content_type_with_image(self):
+        ce = CallbackEvent(event_type='addAttachmentToCard')
+        ce.event_payload = get_sample_data('addAttachmentToCardImage', 'text')
+        self.assertEqual(ce.attachment_content_type, "image/jpeg")
+
+    def test_attachment_content_type_with_image(self):
+        ce = CallbackEvent(webhook_id=0, event_type='addAttachmentToCard')
+        ce.event_payload = get_sample_data('addAttachmentToCardImage', 'text')
+        ce.save()
+        self.assertEqual(ce.action_data['attachment']['content_type'], "image/jpeg")


### PR DESCRIPTION
For the issue: https://github.com/yunojuno/django-trello-webhooks/issues/2
Now, images will be shown inline where all other types of attachment continue to be shown by name. 